### PR TITLE
Add precision argument to ClipperD constructor

### DIFF
--- a/clipper2-wasm/clipper.bindings.cpp
+++ b/clipper2-wasm/clipper.bindings.cpp
@@ -280,7 +280,7 @@ EMSCRIPTEN_BINDINGS(clipper_module) {
 
         // ClipperD
         class_<ClipperD, base<ClipperBase>>("ClipperD")
-        .constructor<>()
+        .constructor<int>()
         .function("AddSubject", &ClipperD::AddSubject, allow_raw_pointers())
         .function("AddOpenSubject", &ClipperD::AddOpenSubject, allow_raw_pointers())
         .function("AddClip", &ClipperD::AddClip, allow_raw_pointers())


### PR DESCRIPTION
Adds the argument to the `ClipperD` constructor to allow the precision to be set.

Thanks for putting this port together! It's working perfectly for me.