### PR TITLE
feat: :sparkles: compile for web webview worker and node

### DIFF
--- a/clipper2-wasm/compile-wasm.sh
+++ b/clipper2-wasm/compile-wasm.sh
@@ -30,14 +30,14 @@ fi
 
 # build ES6
 echo "Building ES6"
-em++ $FLAGS -s EXPORT_ES6=1 -s NO_FILESYSTEM=1 -s ENVIRONMENT='web' -s clipper2-wasm/clipper.bindings.cpp clipper2/CPP/build/libClipper2Z.a -o clipper2-wasm/dist/es/clipper2z.js -s EXPORT_NAME="Clipper2Z" --post-js clipper2-wasm/glue-stub-z.js
+em++ $FLAGS -s EXPORT_ES6=1 -s NO_FILESYSTEM=1 -s ENVIRONMENT='web,webview,worker,node' -s clipper2-wasm/clipper.bindings.cpp clipper2/CPP/build/libClipper2Z.a -o clipper2-wasm/dist/es/clipper2z.js -s EXPORT_NAME="Clipper2Z" --post-js clipper2-wasm/glue-stub-z.js
 
 # build Tools ES6
-em++ $FLAGS -Iclipper2/CPP/Utils -s EXPORT_ES6=1 -s ENVIRONMENT='web' -s clipper2-wasm/clipper-tools.bindings.cpp clipper2/CPP/build/libClipper2Zutils.a clipper2/CPP/build/libClipper2Z.a -o clipper2-wasm/dist/es/clipper2z-utils.js -s EXPORT_NAME="Clipper2ZUtils" -s EXPORTED_FUNCTIONS=[FS] --post-js clipper2-wasm/glue-stub-tools-z.js
+em++ $FLAGS -Iclipper2/CPP/Utils -s EXPORT_ES6=1 -s ENVIRONMENT='web,webview,worker,node' -s clipper2-wasm/clipper-tools.bindings.cpp clipper2/CPP/build/libClipper2Zutils.a clipper2/CPP/build/libClipper2Z.a -o clipper2-wasm/dist/es/clipper2z-utils.js -s EXPORT_NAME="Clipper2ZUtils" -s EXPORTED_FUNCTIONS=[FS] --post-js clipper2-wasm/glue-stub-tools-z.js
 
 # build UMD
 echo "Building UMD"
-em++ $FLAGS -s NO_FILESYSTEM=1 clipper2-wasm/clipper.bindings.cpp clipper2/CPP/build/libClipper2Z.a -o clipper2-wasm/dist/umd/clipper2z.js -s ENVIRONMENT='web' -s EXPORT_NAME="Clipper2ZFactory" --post-js clipper2-wasm/glue-stub-z.js
+em++ $FLAGS -s NO_FILESYSTEM=1 clipper2-wasm/clipper.bindings.cpp clipper2/CPP/build/libClipper2Z.a -o clipper2-wasm/dist/umd/clipper2z.js -s ENVIRONMENT='web,webview,worker,node' -s EXPORT_NAME="Clipper2ZFactory" --post-js clipper2-wasm/glue-stub-z.js
 
 # build Tools UMD
-em++ $FLAGS -Iclipper2/CPP/Utils clipper2-wasm/clipper-tools.bindings.cpp clipper2/CPP/build/libClipper2Zutils.a clipper2/CPP/build/libClipper2Z.a -o clipper2-wasm/dist/umd/clipper2z-utils.js -s ENVIRONMENT='web' -s EXPORT_NAME="Clipper2ZUtilsFactory" -s EXPORTED_FUNCTIONS=[FS] --post-js clipper2-wasm/glue-stub-tools-z.js
+em++ $FLAGS -Iclipper2/CPP/Utils clipper2-wasm/clipper-tools.bindings.cpp clipper2/CPP/build/libClipper2Zutils.a clipper2/CPP/build/libClipper2Z.a -o clipper2-wasm/dist/umd/clipper2z-utils.js -s ENVIRONMENT='web,webview,worker,node' -s EXPORT_NAME="Clipper2ZUtilsFactory" -s EXPORTED_FUNCTIONS=[FS] --post-js clipper2-wasm/glue-stub-tools-z.js


### PR DESCRIPTION


Hi,

thanks for this library! The README.dev was very helpful. I had the demand to use clipper2 in node and web worker environment. So I have added those flags to the .sh file. They are the default parameters for emscripten, so it is a bit redundant now. The file size increased by ~4kb per file. Alternative would be to build a separate node build, but for me this is really usable.

I can also provide the build wasm files, but I thought you might prefer doing this yourself.

Besides this, it might be useful to provide an additional clipper2z.dev.wasm build, so users could import it to read error message more easily. In production i only get back numbers as errors.
